### PR TITLE
Updated autoprefixer to version 6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/MichaelKornblum/gulp-metalsmith-builder",
   "devDependencies": {
-    "autoprefixer": "5.2.0",
+    "autoprefixer": "6.0.3",
     "browser-sync": "2.9.8",
     "browserify": "11.2.0",
     "coffeeify": "1.1.0",


### PR DESCRIPTION
:rocket:

autoprefixer just published version 6.0.3, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>