### PR TITLE
Updated gulp-postcss to version 6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gulp-front-matter": "1.2.3",
     "gulp-imagemin": "2.3.0",
     "gulp-load-plugins": "1.0.0-rc.1",
-    "gulp-postcss": "6.0.0",
+    "gulp-postcss": "6.0.1",
     "gulp-streamify": "0.0.5",
     "gulp-stylus": "2.0.7",
     "gulp-svg-symbols": "0.3.2",


### PR DESCRIPTION
:rocket:

gulp-postcss just published version 6.0.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 3 commits (ahead by 3, behind by 0).

- [bbf0ef5](https://github.com/postcss/gulp-postcss/commit/bbf0ef552a618db3d064b3c154c431c1cff458d5): Updated vinyl-sourcemaps-apply
- [1ba7f1d](https://github.com/postcss/gulp-postcss/commit/1ba7f1d004caaf1d7de97e3838f2555117ec0d88): Merge pull request #60 from postcss/56-add-syntax-options
- [1e684db](https://github.com/postcss/gulp-postcss/commit/1e684db776df2f27bb047cf6b87a5b99e68903b1): Added an example and a test to pass options to PostCSS

See the [full diff](https://github.com/postcss/gulp-postcss/compare/75d52ccbb6f4ba8fc498dbd06520ed9b5c71ee38...bbf0ef552a618db3d064b3c154c431c1cff458d5).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>