### PR TITLE
Updated gulp-stylus to version 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "gulp-load-plugins": "1.0.0-rc.1",
     "gulp-postcss": "6.0.1",
     "gulp-streamify": "0.0.5",
-    "gulp-stylus": "2.0.7",
+    "gulp-stylus": "2.1.0",
     "gulp-svg-symbols": "0.3.2",
     "gulp-uglify": "1.4.1",
     "gulp-util": "3.0.6",


### PR DESCRIPTION
:rocket:

gulp-stylus just published version 2.1.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 4 commits (ahead by 4, behind by 0).

- [9476d7d](https://github.com/stevelacy/gulp-stylus/commit/9476d7dc5d18baa654a9a12c148198fdf81bc6fc): 2.1.0
- [2d2891b](https://github.com/stevelacy/gulp-stylus/commit/2d2891b4c5d1cd9fcbfe36e6cb222f9292f14f63): convert tabs to spaces
- [fbbec31](https://github.com/stevelacy/gulp-stylus/commit/fbbec31cbf0754ea7b927ef640bf145561db73f3): Merge pull request #145 from revyh/master
- [9ea03bd](https://github.com/stevelacy/gulp-stylus/commit/9ea03bd7b8f9c75fc7257699b601e74331ee18f7): Replace 'makePathRelative' with 'basePath' - #109

See the [full diff](https://github.com/stevelacy/gulp-stylus/compare/25827f785ecee58daba04352e518d6a2fb61a702...9476d7dc5d18baa654a9a12c148198fdf81bc6fc).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>